### PR TITLE
Fixing footerLang Bugs

### DIFF
--- a/stylesheets/linkmanager/linkmanager.js
+++ b/stylesheets/linkmanager/linkmanager.js
@@ -58,8 +58,9 @@ var linkmanager = {
                     if(ahorn.settings.uniFooter){
                         await initUniFooter();
                         loadUniFooter();
+                    }else{
+                        await setFooterLangs();
                     }
-                    await setFooterLangs();
                     await setAutoNavbar();
                     autoLink_initLangs();
                     setAutoLinks();
@@ -77,8 +78,9 @@ var linkmanager = {
         if(ahorn.settings.uniFooter){
             await initUniFooter();
             loadUniFooter();
+        }else{
+            await setFooterLangs();
         }
-        await setFooterLangs();
         await setAutoNavbar();
         autoLink_initLangs();
         setAutoLinks();


### PR DESCRIPTION
Problem war, dass die footerLangs funktion doppelt aufgerufen wurde: Einmal vom Linkmanager, Einmal von UniFooter.
Behoben durch if bedingung im linkmanager.